### PR TITLE
Fix Filebeat password

### DIFF
--- a/etc/filebeat/filebeat.yml
+++ b/etc/filebeat/filebeat.yml
@@ -16,4 +16,4 @@ filebeat.inputs:
 output.elasticsearch:
   hosts: ["elasticsearch:9200"]
   username: elastic
-  password: changeme
+  password: elastic


### PR DESCRIPTION
## Summary
- align Filebeat's Elasticsearch credentials with stack password

## Testing
- `./gradlew test` *(fails: No route to host)*